### PR TITLE
Implement truncated hashes per FIPS PUB 180-4

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,9 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE := sha
+LOCAL_SRC_FILES := \
+	sha1.c \
+	sha2.c \
+	hmac.c
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
+include $(BUILD_STATIC_LIBRARY)

--- a/sha-512-t.c
+++ b/sha-512-t.c
@@ -1,8 +1,24 @@
 /*
- *  sha-512-t.c - Copyright 2016, Michael Mohr
- *  Released under the GPL version 3.
- *  This is a quick hack that can be used to pre-calculate SHA-512/t IVs.
- *  See: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
+---------------------------------------------------------------------------
+Copyright (c) 2016, Michael Mohr, California, US. All rights reserved.
+
+The redistribution and use of this software (with or without changes)
+is allowed without the payment of fees or royalties provided that:
+
+  source code distributions include the above copyright notice, this
+  list of conditions and the following disclaimer;
+
+  binary distributions include the above copyright notice, this list
+  of conditions and the following disclaimer in their documentation.
+
+This software is provided 'as is' with no explicit or implied warranties
+in respect of its operation, including, but not limited to, correctness
+and fitness for purpose.
+---------------------------------------------------------------------------
+Issue Date: 07 Jan 2016
+
+This is a program which can be used to pre-calculate SHA-512/t IVs.
+  For more info: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
 */
 
 #include <stdio.h>

--- a/sha-512-t.c
+++ b/sha-512-t.c
@@ -1,0 +1,43 @@
+/*
+ *  sha-512-t.c - Copyright 2016, Michael Mohr
+ *  Released under the GPL version 3.
+ *  This is a quick hack that can be used to pre-calculate SHA-512/t IVs.
+ *  See: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
+*/
+
+#include <stdio.h>
+#include <inttypes.h>
+#include <endian.h>
+
+#include "sha2.h"
+
+const char *truncated_names[4] = {
+    "SHA-512/256",
+    "SHA-512/224",
+    "SHA-512/192",
+    "SHA-512/128",
+};
+
+int main(int argc, char **argv) {
+    unsigned int i, j;
+    sha512_ctx cx[1];
+    union {
+        uint64_t qwords[8];
+        uint8_t bytes[SHA512_DIGEST_SIZE];
+    } hval;
+
+    for(i=0; i<4; i++) {
+        printf("/* FIPS PUB 180-4: %s */\nconst uint64_t i512_xxx[8] =\n{", truncated_names[i]);
+        sha512_begin(cx);
+        for(j=0; j<8; j++)
+            cx[0].hash[j] ^= be64toh(0xa5a5a5a5a5a5a5a5);
+        sha512_hash((const unsigned char *)truncated_names[i], 11, cx);
+        sha512_end(hval.bytes, cx);
+        for(j=0; j<8; j++) {
+            if(((j % 2) == 0))
+                printf("\n    ");
+            printf("li_64(%016lx), ", htobe64(hval.qwords[j]));
+        }
+        printf("\n};\n\n");
+    }
+}

--- a/sha2.c
+++ b/sha2.c
@@ -817,6 +817,38 @@ VOID_RETURN sha512(unsigned char hval[], const unsigned char data[], unsigned lo
     sha_end2(hval, cx, SHA512_DIGEST_SIZE);
 }
 
+VOID_RETURN sha512_256(unsigned char hval[], const unsigned char data[], unsigned long len)
+{   sha512_ctx  cx[1];
+
+    sha512_256_begin(cx);
+    sha512_hash(data, len, cx);
+    sha512_256_end(hval, cx);
+}
+
+VOID_RETURN sha512_224(unsigned char hval[], const unsigned char data[], unsigned long len)
+{   sha512_ctx  cx[1];
+
+    sha512_224_begin(cx);
+    sha512_hash(data, len, cx);
+    sha512_224_end(hval, cx);
+}
+
+VOID_RETURN sha512_192(unsigned char hval[], const unsigned char data[], unsigned long len)
+{   sha512_ctx  cx[1];
+
+    sha512_192_begin(cx);
+    sha512_hash(data, len, cx);
+    sha512_192_end(hval, cx);
+}
+
+VOID_RETURN sha512_128(unsigned char hval[], const unsigned char data[], unsigned long len)
+{   sha512_ctx  cx[1];
+
+    sha512_128_begin(cx);
+    sha512_hash(data, len, cx);
+    sha512_128_end(hval, cx);
+}
+
 #endif
 
 #if defined(SHA_2)

--- a/sha2.c
+++ b/sha2.c
@@ -706,12 +706,52 @@ VOID_RETURN sha384(unsigned char hval[], const unsigned char data[], unsigned lo
 
 /* SHA512 initialisation data   */
 
-const uint64_t  i512[80] =
+static const uint64_t i512[8] =
 {
     li_64(6a09e667f3bcc908), li_64(bb67ae8584caa73b),
     li_64(3c6ef372fe94f82b), li_64(a54ff53a5f1d36f1),
     li_64(510e527fade682d1), li_64(9b05688c2b3e6c1f),
     li_64(1f83d9abfb41bd6b), li_64(5be0cd19137e2179)
+};
+
+/* FIPS PUB 180-4: SHA-512/256 */
+
+static const uint64_t i512_256[8] =
+{
+    li_64(22312194fc2bf72c), li_64(9f555fa3c84c64c2),
+    li_64(2393b86b6f53b151), li_64(963877195940eabd),
+    li_64(96283ee2a88effe3), li_64(be5e1e2553863992),
+    li_64(2b0199fc2c85b8aa), li_64(0eb72ddc81c52ca2),
+};
+
+/* FIPS PUB 180-4: SHA-512/224 */
+
+static const uint64_t i512_224[8] =
+{
+    li_64(8c3d37c819544da2), li_64(73e1996689dcd4d6),
+    li_64(1dfab7ae32ff9c82), li_64(679dd514582f9fcf),
+    li_64(0f6d2b697bd44da8), li_64(77e36f7304c48942),
+    li_64(3f9d85a86a1d36c8), li_64(1112e6ad91d692a1),
+};
+
+/* FIPS PUB 180-4: SHA-512/192 */
+
+static const uint64_t i512_192[8] =
+{
+    li_64(010176140648b233), li_64(db92aeb1eebadd6f),
+    li_64(83a9e27aa1d5ea62), li_64(ec95f77eb609b4e1),
+    li_64(71a99185c75caefa), li_64(006e8f08baf32e3c),
+    li_64(6a2b21abd2db2aec), li_64(24926cdbd918a27f),
+};
+
+/* FIPS PUB 180-4: SHA-512/128 */
+
+static const uint64_t i512_128[8] =
+{
+    li_64(c953a21464c3e8cc), li_64(06cc9cfd166a34b5),
+    li_64(647e88dabf8b24ab), li_64(8513e4dc05a078ac),
+    li_64(7266fcfb7cba0534), li_64(854a78e2ecd19b93),
+    li_64(8618061711cec2dd), li_64(b20d8506efb929b1),
 };
 
 VOID_RETURN sha512_begin(sha512_ctx ctx[1])
@@ -720,9 +760,53 @@ VOID_RETURN sha512_begin(sha512_ctx ctx[1])
     memcpy(ctx->hash, i512, sizeof(ctx->hash));
 }
 
+VOID_RETURN sha512_256_begin(sha512_ctx ctx[1])
+{
+    memset(ctx, 0, sizeof(sha512_ctx));
+    memcpy(ctx->hash, i512_256, 8 * sizeof(uint_64t));
+}
+
+VOID_RETURN sha512_224_begin(sha512_ctx ctx[1])
+{
+    memset(ctx, 0, sizeof(sha512_ctx));
+    memcpy(ctx->hash, i512_224, 8 * sizeof(uint_64t));
+}
+
+VOID_RETURN sha512_192_begin(sha512_ctx ctx[1])
+{
+    memset(ctx, 0, sizeof(sha512_ctx));
+    memcpy(ctx->hash, i512_192, 8 * sizeof(uint_64t));
+}
+
+VOID_RETURN sha512_128_begin(sha512_ctx ctx[1])
+{
+    memset(ctx, 0, sizeof(sha512_ctx));
+    memcpy(ctx->hash, i512_128, 8 * sizeof(uint_64t));
+}
+
 VOID_RETURN sha512_end(unsigned char hval[], sha512_ctx ctx[1])
 {
     sha_end2(hval, ctx, SHA512_DIGEST_SIZE);
+}
+
+VOID_RETURN sha512_256_end(unsigned char hval[], sha512_ctx ctx[1])
+{
+    sha_end2(hval, ctx, 32);
+}
+
+VOID_RETURN sha512_224_end(unsigned char hval[], sha512_ctx ctx[1])
+{
+    sha_end2(hval, ctx, 28);
+}
+
+VOID_RETURN sha512_192_end(unsigned char hval[], sha512_ctx ctx[1])
+{
+    sha_end2(hval, ctx, 24);
+}
+
+VOID_RETURN sha512_128_end(unsigned char hval[], sha512_ctx ctx[1])
+{
+    sha_end2(hval, ctx, 16);
 }
 
 VOID_RETURN sha512(unsigned char hval[], const unsigned char data[], unsigned long len)

--- a/sha2.c
+++ b/sha2.c
@@ -734,7 +734,7 @@ static const uint64_t i512_224[8] =
     li_64(3f9d85a86a1d36c8), li_64(1112e6ad91d692a1),
 };
 
-/* FIPS PUB 180-4: SHA-512/192 */
+/* FIPS PUB 180-4: SHA-512/192 (unsanctioned; facilitates using AES-192) */
 
 static const uint64_t i512_192[8] =
 {
@@ -744,7 +744,7 @@ static const uint64_t i512_192[8] =
     li_64(6a2b21abd2db2aec), li_64(24926cdbd918a27f),
 };
 
-/* FIPS PUB 180-4: SHA-512/128 */
+/* FIPS PUB 180-4: SHA-512/128 (unsanctioned; facilitates using AES-128) */
 
 static const uint64_t i512_128[8] =
 {

--- a/sha2.c
+++ b/sha2.c
@@ -791,22 +791,22 @@ VOID_RETURN sha512_end(unsigned char hval[], sha512_ctx ctx[1])
 
 VOID_RETURN sha512_256_end(unsigned char hval[], sha512_ctx ctx[1])
 {
-    sha_end2(hval, ctx, 32);
+    sha_end2(hval, ctx, 256 >> 3);
 }
 
 VOID_RETURN sha512_224_end(unsigned char hval[], sha512_ctx ctx[1])
 {
-    sha_end2(hval, ctx, 28);
+    sha_end2(hval, ctx, 224 >> 3);
 }
 
 VOID_RETURN sha512_192_end(unsigned char hval[], sha512_ctx ctx[1])
 {
-    sha_end2(hval, ctx, 24);
+    sha_end2(hval, ctx, 192 >> 3);
 }
 
 VOID_RETURN sha512_128_end(unsigned char hval[], sha512_ctx ctx[1])
 {
-    sha_end2(hval, ctx, 16);
+    sha_end2(hval, ctx, 128 >> 3);
 }
 
 VOID_RETURN sha512(unsigned char hval[], const unsigned char data[], unsigned long len)

--- a/sha2.c
+++ b/sha2.c
@@ -706,7 +706,7 @@ VOID_RETURN sha384(unsigned char hval[], const unsigned char data[], unsigned lo
 
 /* SHA512 initialisation data   */
 
-static const uint64_t i512[8] =
+static const uint64_t i512[SHA512_DIGEST_SIZE >> 3] =
 {
     li_64(6a09e667f3bcc908), li_64(bb67ae8584caa73b),
     li_64(3c6ef372fe94f82b), li_64(a54ff53a5f1d36f1),
@@ -716,7 +716,7 @@ static const uint64_t i512[8] =
 
 /* FIPS PUB 180-4: SHA-512/256 */
 
-static const uint64_t i512_256[8] =
+static const uint64_t i512_256[SHA512_DIGEST_SIZE >> 3] =
 {
     li_64(22312194fc2bf72c), li_64(9f555fa3c84c64c2),
     li_64(2393b86b6f53b151), li_64(963877195940eabd),
@@ -726,7 +726,7 @@ static const uint64_t i512_256[8] =
 
 /* FIPS PUB 180-4: SHA-512/224 */
 
-static const uint64_t i512_224[8] =
+static const uint64_t i512_224[SHA512_DIGEST_SIZE >> 3] =
 {
     li_64(8c3d37c819544da2), li_64(73e1996689dcd4d6),
     li_64(1dfab7ae32ff9c82), li_64(679dd514582f9fcf),
@@ -736,7 +736,7 @@ static const uint64_t i512_224[8] =
 
 /* FIPS PUB 180-4: SHA-512/192 (unsanctioned; facilitates using AES-192) */
 
-static const uint64_t i512_192[8] =
+static const uint64_t i512_192[SHA512_DIGEST_SIZE >> 3] =
 {
     li_64(010176140648b233), li_64(db92aeb1eebadd6f),
     li_64(83a9e27aa1d5ea62), li_64(ec95f77eb609b4e1),
@@ -746,7 +746,7 @@ static const uint64_t i512_192[8] =
 
 /* FIPS PUB 180-4: SHA-512/128 (unsanctioned; facilitates using AES-128) */
 
-static const uint64_t i512_128[8] =
+static const uint64_t i512_128[SHA512_DIGEST_SIZE >> 3] =
 {
     li_64(c953a21464c3e8cc), li_64(06cc9cfd166a34b5),
     li_64(647e88dabf8b24ab), li_64(8513e4dc05a078ac),

--- a/sha2.c
+++ b/sha2.c
@@ -763,25 +763,25 @@ VOID_RETURN sha512_begin(sha512_ctx ctx[1])
 VOID_RETURN sha512_256_begin(sha512_ctx ctx[1])
 {
     memset(ctx, 0, sizeof(sha512_ctx));
-    memcpy(ctx->hash, i512_256, 8 * sizeof(uint_64t));
+    memcpy(ctx->hash, i512_256, sizeof(ctx->hash));
 }
 
 VOID_RETURN sha512_224_begin(sha512_ctx ctx[1])
 {
     memset(ctx, 0, sizeof(sha512_ctx));
-    memcpy(ctx->hash, i512_224, 8 * sizeof(uint_64t));
+    memcpy(ctx->hash, i512_224, sizeof(ctx->hash));
 }
 
 VOID_RETURN sha512_192_begin(sha512_ctx ctx[1])
 {
     memset(ctx, 0, sizeof(sha512_ctx));
-    memcpy(ctx->hash, i512_192, 8 * sizeof(uint_64t));
+    memcpy(ctx->hash, i512_192, sizeof(ctx->hash));
 }
 
 VOID_RETURN sha512_128_begin(sha512_ctx ctx[1])
 {
     memset(ctx, 0, sizeof(sha512_ctx));
-    memcpy(ctx->hash, i512_128, 8 * sizeof(uint_64t));
+    memcpy(ctx->hash, i512_128, sizeof(ctx->hash));
 }
 
 VOID_RETURN sha512_end(unsigned char hval[], sha512_ctx ctx[1])

--- a/sha2.c
+++ b/sha2.c
@@ -821,7 +821,7 @@ VOID_RETURN sha512_256(unsigned char hval[], const unsigned char data[], unsigne
 {   sha512_ctx  cx[1];
 
     sha512_256_begin(cx);
-    sha512_hash(data, len, cx);
+    sha512_256_hash(data, len, cx);
     sha512_256_end(hval, cx);
 }
 
@@ -829,7 +829,7 @@ VOID_RETURN sha512_224(unsigned char hval[], const unsigned char data[], unsigne
 {   sha512_ctx  cx[1];
 
     sha512_224_begin(cx);
-    sha512_hash(data, len, cx);
+    sha512_224_hash(data, len, cx);
     sha512_224_end(hval, cx);
 }
 
@@ -837,7 +837,7 @@ VOID_RETURN sha512_192(unsigned char hval[], const unsigned char data[], unsigne
 {   sha512_ctx  cx[1];
 
     sha512_192_begin(cx);
-    sha512_hash(data, len, cx);
+    sha512_192_hash(data, len, cx);
     sha512_192_end(hval, cx);
 }
 
@@ -845,7 +845,7 @@ VOID_RETURN sha512_128(unsigned char hval[], const unsigned char data[], unsigne
 {   sha512_ctx  cx[1];
 
     sha512_128_begin(cx);
-    sha512_hash(data, len, cx);
+    sha512_128_hash(data, len, cx);
     sha512_128_end(hval, cx);
 }
 

--- a/sha2.c
+++ b/sha2.c
@@ -814,7 +814,7 @@ VOID_RETURN sha512(unsigned char hval[], const unsigned char data[], unsigned lo
 
     sha512_begin(cx);
     sha512_hash(data, len, cx);
-    sha_end2(hval, cx, SHA512_DIGEST_SIZE);
+    sha512_end(hval, cx);
 }
 
 VOID_RETURN sha512_256(unsigned char hval[], const unsigned char data[], unsigned long len)

--- a/sha2.h
+++ b/sha2.h
@@ -139,6 +139,22 @@ VOID_RETURN sha512_hash(const unsigned char data[], unsigned long len, sha512_ct
 VOID_RETURN sha512_end(unsigned char hval[], sha512_ctx ctx[1]);
 VOID_RETURN sha512(unsigned char hval[], const unsigned char data[], unsigned long len);
 
+VOID_RETURN sha512_256_begin(sha512_ctx ctx[1]);
+#define sha512_256_hash sha512_hash
+VOID_RETURN sha512_256_end(unsigned char hval[], sha512_ctx ctx[1]);
+
+VOID_RETURN sha512_224_begin(sha512_ctx ctx[1]);
+#define sha512_224_hash sha512_hash
+VOID_RETURN sha512_224_end(unsigned char hval[], sha512_ctx ctx[1]);
+
+VOID_RETURN sha512_192_begin(sha512_ctx ctx[1]);
+#define sha512_192_hash sha512_hash
+VOID_RETURN sha512_192_end(unsigned char hval[], sha512_ctx ctx[1]);
+
+VOID_RETURN sha512_128_begin(sha512_ctx ctx[1]);
+#define sha512_128_hash sha512_hash
+VOID_RETURN sha512_128_end(unsigned char hval[], sha512_ctx ctx[1]);
+
 INT_RETURN  sha2_begin(unsigned long size, sha2_ctx ctx[1]);
 VOID_RETURN sha2_hash(const unsigned char data[], unsigned long len, sha2_ctx ctx[1]);
 VOID_RETURN sha2_end(unsigned char hval[], sha2_ctx ctx[1]);

--- a/sha2.h
+++ b/sha2.h
@@ -142,18 +142,22 @@ VOID_RETURN sha512(unsigned char hval[], const unsigned char data[], unsigned lo
 VOID_RETURN sha512_256_begin(sha512_ctx ctx[1]);
 #define sha512_256_hash sha512_hash
 VOID_RETURN sha512_256_end(unsigned char hval[], sha512_ctx ctx[1]);
+VOID_RETURN sha512_256(unsigned char hval[], const unsigned char data[], unsigned long len);
 
 VOID_RETURN sha512_224_begin(sha512_ctx ctx[1]);
 #define sha512_224_hash sha512_hash
 VOID_RETURN sha512_224_end(unsigned char hval[], sha512_ctx ctx[1]);
+VOID_RETURN sha512_224(unsigned char hval[], const unsigned char data[], unsigned long len);
 
 VOID_RETURN sha512_192_begin(sha512_ctx ctx[1]);
 #define sha512_192_hash sha512_hash
 VOID_RETURN sha512_192_end(unsigned char hval[], sha512_ctx ctx[1]);
+VOID_RETURN sha512_192(unsigned char hval[], const unsigned char data[], unsigned long len);
 
 VOID_RETURN sha512_128_begin(sha512_ctx ctx[1]);
 #define sha512_128_hash sha512_hash
 VOID_RETURN sha512_128_end(unsigned char hval[], sha512_ctx ctx[1]);
+VOID_RETURN sha512_128(unsigned char hval[], const unsigned char data[], unsigned long len);
 
 INT_RETURN  sha2_begin(unsigned long size, sha2_ctx ctx[1]);
 VOID_RETURN sha2_hash(const unsigned char data[], unsigned long len, sha2_ctx ctx[1]);

--- a/sha_test.c
+++ b/sha_test.c
@@ -100,6 +100,31 @@ struct
  }
 };
 
+/*
+ *  FIPS PUB 180-4 test vectors for SHA-512/t obtained from:
+ *    http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA512_224.pdf
+ *    http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA512_256.pdf
+ */
+struct
+{   char          *str;
+    unsigned char sha512_224[224 >> 3];
+    unsigned char sha512_256[256 >> 3];
+} byte_v2[2] =
+{
+ {  "abc",
+    {0x46, 0x34, 0x27, 0x0F, 0x70, 0x7B, 0x6A, 0x54, 0xDA, 0xAE, 0x75, 0x30, 0x46, 0x08,
+     0x42, 0xE2, 0x0E, 0x37, 0xED, 0x26, 0x5C, 0xEE, 0xE9, 0xA4, 0x3E, 0x89, 0x24, 0xAA},
+    {0x53, 0x04, 0x8E, 0x26, 0x81, 0x94, 0x1E, 0xF9, 0x9B, 0x2E, 0x29, 0xB7, 0x6B, 0x4C, 0x7D, 0xAB,
+     0xE4, 0xC2, 0xD0, 0xC6, 0x34, 0xFC, 0x6D, 0x46, 0xE0, 0xE2, 0xF1, 0x31, 0x07, 0xE7, 0xAF, 0x23}
+ },
+ {  "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
+    {0x23, 0xFE, 0xC5, 0xBB, 0x94, 0xD6, 0x0B, 0x23, 0x30, 0x81, 0x92, 0x64, 0x0B, 0x0C,
+     0x45, 0x33, 0x35, 0xD6, 0x64, 0x73, 0x4F, 0xE4, 0x0E, 0x72, 0x68, 0x67, 0x4A, 0xF9},
+    {0x39, 0x28, 0xE1, 0x84, 0xFB, 0x86, 0x90, 0xF8, 0x40, 0xDA, 0x39, 0x88, 0x12, 0x1D, 0x31, 0xBE,
+     0x65, 0xCB, 0x9D, 0x3E, 0xF8, 0x3E, 0xE6, 0x14, 0x6F, 0xEA, 0xC8, 0x61, 0xE1, 0x9B, 0x56, 0x3A}
+ }
+};
+
 /* SHA1 test vectors from Jim Gillogly  */
 /* and Francois Grieu. In this version  */
 /* they are defined as a repeating byte */
@@ -693,6 +718,30 @@ void do_vecs(FILE *fo, hash_ctx hc[1])
     fprintf(fo, "\n");
 }
 
+void do_vecs_fips_180_4(FILE *fo)
+{   char h[SHA2_MAX_DIGEST_SIZE];
+    int i, l, n;
+
+    for(i = 0; i < 2; ++i)
+    {   l = (int)strlen(byte_v2[i].str);
+        memset(h, 0, sizeof(h));
+        sha512_224(h, byte_v2[i].str, l);
+        n = memcmp(h, byte_v2[i].sha512_224, 224 >> 3);
+        if(n != 0)
+            fprintf(fo, "\nSHA-512/224 failed for input \"%s\"", byte_v2[i].str);
+        else
+            fprintf(fo, "\nSHA-512/224 succeeded for input \"%s\"", byte_v2[i].str);
+        memset(h, 0, sizeof(h));
+        sha512_256(h, byte_v2[i].str, l);
+        n = memcmp(h, byte_v2[i].sha512_256, 256 >> 3);
+        if(n != 0)
+            fprintf(fo, "\nSHA-512/256 failed for input \"%s\"", byte_v2[i].str);
+        else
+            fprintf(fo, "\nSHA-512/256 succeeded for input \"%s\"", byte_v2[i].str);
+    }
+    fprintf(fo, "\n");
+}
+
 void do_tests(FILE *fo, enum hash alg, enum test t)
 {   hash_ctx      hc[1];
 
@@ -785,6 +834,7 @@ int main(void)
 #if defined(TEST_SHA512)
     alg = SHA512 | (SHA2_BITS ? BITS : 0);
     do_tests(fo, alg, tests);
+    do_vecs_fips_180_4(fo);
 #endif
 
 #else


### PR DESCRIPTION
FIPS 180-4 provides guidance regarding how SHA-512 may be truncated to enable e.g. block ciphers with a smaller key size than 512 bits.  I've pre-calculated the initialization vectors for SHA-512/256 and SHA-512/224, plus two additional (unsanctioned) variants, SHA-512/192 and SHA-512/128.  I've also updated the test suite with test vector data from NIST.
